### PR TITLE
[feature][generate-article] update template for coverFileName

### DIFF
--- a/content/people.json
+++ b/content/people.json
@@ -7,6 +7,10 @@
     {
       "name": "Wafaa Jaunnoo",
       "url": "https://github.com/wafaajaunnoo"
+    },
+    {
+      "name": "Ricky Blondel",
+      "url": "https://github.com/b10nde1"
     }
   ],
   "contributors": [

--- a/scripts/generate-article.js
+++ b/scripts/generate-article.js
@@ -13,6 +13,8 @@ const generateArticle = async () => {
 
   console.log(figlet.textSync("The Philosophical Code")); // Ascii Art
 
+  let useDefaultCover = true;
+
   const questions = [
     {
       type: "input",
@@ -58,20 +60,33 @@ const generateArticle = async () => {
       })
     },
     {
+      type: 'toggle',
+      name: "proceed",
+      message: "Would you like to use our default article cover for now? You can always change it later.",
+      enabled: "Yep",
+      disabled: "Nope",
+      result: (value) => {
+        useDefaultCover = value;
+        return value;
+      }
+    },
+    {
+      skip: () => useDefaultCover,
       type: 'input',
       name: 'defaultCover',
-      message: "Please specify the path for the cover (type default to use the default cover)",
-      validate: (value) => {        
-        
+      initial: "./scripts/templates/cover.webp",
+      message: "Please specify the path for the cover you want to use. Type 'skip' if you still want to use the default.",
+      validate: (value) => {
+
         // Checks if cover exist
-        if (!fs.existsSync(value === "default" ? "./scripts/templates/cover.webp" : value)) {
-          return "File does not exist. Please verify the path or type 'default'";
+        if (!fs.existsSync(value === "skip" ? "./scripts/templates/cover.webp" : value)) {
+          return "File does not exist. Please verify the path or type 'skip'";
         }
 
         return true;
       },
       result: (value) => ({
-        generalPath: value === "default"
+        generalPath: value === "skip"
           ? "./scripts/templates/cover.webp" : value
       })
     }

--- a/scripts/templates/article.md
+++ b/scripts/templates/article.md
@@ -4,9 +4,9 @@ title: "{#articleNormalTitle}"
 description: "Please add your description here. This should match the one below."
 author: "{#githubName}"
 authorUrl: "{#githubURL}"
-ogImagePath: "/images/{#articleKebabTitle}/cover.webp"
+ogImagePath: "/images/{#articleKebabTitle}/{#coverFileName}"
 date: 2000-01-01
 ---
-![{#articleNormalTitle}](/images/{#articleKebabTitle}/cover.webp)
+![{#articleNormalTitle}](/images/{#articleKebabTitle}/{#coverFileName})
 
 > Please add your description here. Don't forget to change the date just above.


### PR DESCRIPTION
adding an option to allow user to give the path / use an existing file from local instead of default cover.

After the title prompt,
_ ask user if he want to use default or existing cover (type default if want the default one) 
=> the script will check if exist | if not ask the user again
_ if above passed, create everything and use the defaultCover obj with the default of new cover path

Files updated :
_ generate-article.js > add the new prompt question and logic for cover
_ article.md > add variable {#coverFileName}